### PR TITLE
Updated Config

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -2,24 +2,27 @@ set -g allow-rename off
 set -g base-index 1
 set -g default-terminal 'screen-256color'
 set -g display-time 4000
-set -g history-limit 10000
+set -g history-limit 1000000
 set -g pane-base-index 1
 set -g prefix C-a
 set -g prefix2 C-b
 set -g renumber-windows on
 set -g repeat-time 250
 set -g status-interval 3
+set -g mouse on
 setw -g mode-keys vi
 
 # message bar style
 set -g message-command-style 'fg=#000000,bg=#c19a00'
 set -g message-style 'fg=#000000,bg=#c19a00'
+
 # status bar style
 set -g status-left '#[fg=#ffffff,bg=#005f5f] #S '
 set -g status-left-length 64
 set -g status-right '#[fg=#ffffff,bg=#800d5d] #(whoami) #[fg=#ffffff,bg=#1a4dad] %d/%m/%Y %H:%M '
 set -g status-right-length 1024
 set -g status-style 'fg=#ffffff,bg=#303030'
+
 # window status style
 set -g window-status-current-format '#[fg=#ffffff,bg=#5f87ff] #I #W '
 set -g window-status-format '#[fg=#ffffff,bg=#303030] #I #W '
@@ -36,18 +39,33 @@ bind -n M-Right select-pane -R
 bind -n M-z resize-pane -Z
 bind b break-pane
 bind x kill-pane
+
 # window bindings
 bind -n M-n next-window
 bind -n M-p previous-window
 bind C-x setw synchronize-panes
 bind + new-window -c '#{pane_current_path}'
 bind X kill-window
+bind o source-file ~/.tmux.conf
+
+# split panes using | and - because its more intuitive and % and " is ridiculous!
+bind | split-window -h
+bind - split-window -v
+unbind '"'
+unbind %
+
 # copy paste bindings
 bind -n M-c copy-mode
 bind -n M-v paste-buffer
 bind -T copy-mode-vi v send-keys -X begin-selection
-bind -T copy-mode-vi y send-keys -X copy-selection-and-cancel
+bind -T copy-mode-vi y send-keys -X copy-selection
 
+# Much better user experience with copying via mouse scroll, simply highlight and press y to copy, best part is it won't exit vi mode, won't auto scroll down to the bottom either and if you want to remove selection just click anywhere and selection will be removed.
+unbind -T copy-mode-vi MouseDragEnd1Pane
+bind-key -T copy-mode-vi MouseDown1Pane select-pane\; send-keys -X clear-selection
+bind -n MouseDrag1Pane if -Ft= '#{mouse_any_flag}' 'if -Ft= \"#{pane_in_mode}\" \"copy-mode -eM\" \"send-keys -M\"' 'copy-mode -eM'
+
+# set plugins
 set -g @plugin 'tmux-plugins/tmux-logging'
 set -g @plugin 'tmux-plugins/tmux-pain-control'
 set -g @plugin 'tmux-plugins/tmux-sidebar'


### PR DESCRIPTION
Quality of life changes to prevent you from banging your head against the wall while using this. 

1. Much better user experience with copying via mouse scroll, simply highlight and press y to copy, best part is it won't exit vi mode, won't auto scroll down to the bottom either and if you want to remove selection just click anywhere and selection will be removed.
2. More intuitive pane splitting using - and | to visualize horizontal and vertical instead of the default " and % which was utterly ridiculous. 
